### PR TITLE
[Feat/#17] JWT 인증 예외 처리 표준화 및 EntryPoint 구현

### DIFF
--- a/src/main/java/sw/momolab/server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/sw/momolab/server/apiPayload/code/status/ErrorStatus.java
@@ -20,6 +20,7 @@ public enum ErrorStatus implements BaseErrorCode {
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_401_02", "만료된 JWT 토큰입니다."),
     TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "AUTH_401_03", "유효하지 않은 JWT 서명 또는 형식입니다."),
     TOKEN_GENERAL_ERROR(HttpStatus.UNAUTHORIZED, "AUTH_401_04", "기타 토큰 인증 오류입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_401_05", "인증 정보가 필요합니다."),
 
     ;
 

--- a/src/main/java/sw/momolab/server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/sw/momolab/server/apiPayload/code/status/ErrorStatus.java
@@ -17,6 +17,9 @@ public enum ErrorStatus implements BaseErrorCode {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_403", "금지된 요청입니다."),
 
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH_401_01", "아이디 또는 비밀번호가 일치하지 않습니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_401_02", "만료된 JWT 토큰입니다."),
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "AUTH_401_03", "유효하지 않은 JWT 서명 또는 형식입니다."),
+    TOKEN_GENERAL_ERROR(HttpStatus.UNAUTHORIZED, "AUTH_401_04", "기타 토큰 인증 오류입니다."),
 
     ;
 

--- a/src/main/java/sw/momolab/server/apiPayload/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/sw/momolab/server/apiPayload/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,47 @@
+package sw.momolab.server.apiPayload.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import sw.momolab.server.apiPayload.code.ErrorReasonDTO;
+import sw.momolab.server.apiPayload.code.status.ErrorStatus;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    // 인증되지 않은 사용자가 보호된 리소스에 접근하려 할 때 호출
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authenticationException) throws IOException, ServletException {
+
+        // 1. 응답 상태 및 Content-Type 설정
+        ErrorStatus errorStatus = ErrorStatus.UNAUTHORIZED;
+        response.setStatus(errorStatus.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        // 2. ErrorStatus의 정보를 사용하여 ErrorReasonDTO 객체 생성
+        ErrorReasonDTO errorReasonDTO = ErrorReasonDTO.builder()
+                .httpStatus(errorStatus.getHttpStatus())
+                .isSuccess(false)
+                .code(errorStatus.getCode())
+                .message(errorStatus.getMessage())
+                .build();
+
+        // 3. JSON으로 변환하여 응답 스트림에 쓰기
+        response.getWriter().write(objectMapper.writeValueAsString(errorReasonDTO));
+    }
+}

--- a/src/main/java/sw/momolab/server/apiPayload/exception/TokenHandler.java
+++ b/src/main/java/sw/momolab/server/apiPayload/exception/TokenHandler.java
@@ -1,0 +1,9 @@
+package sw.momolab.server.apiPayload.exception;
+
+import sw.momolab.server.apiPayload.code.BaseErrorCode;
+
+public class TokenHandler extends GeneralException {
+    public TokenHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/sw/momolab/server/config/SecurityConfig.java
+++ b/src/main/java/sw/momolab/server/config/SecurityConfig.java
@@ -6,11 +6,13 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
+import sw.momolab.server.apiPayload.exception.CustomAuthenticationEntryPoint;
 import sw.momolab.server.filter.JwtAuthenticationFilter;
 import sw.momolab.server.service.userService.CustomUserDetailsService;
 
@@ -20,11 +22,13 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomUserDetailsService customUserDetailsService;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final CorsConfigurationSource corsConfigurationSource;
 
-    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter, CustomUserDetailsService customUserDetailsService, CorsConfigurationSource corsConfigurationSource) {
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter, CustomUserDetailsService customUserDetailsService, CustomAuthenticationEntryPoint customAuthenticationEntryPoint, CorsConfigurationSource corsConfigurationSource) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
         this.customUserDetailsService = customUserDetailsService;
+        this.customAuthenticationEntryPoint = customAuthenticationEntryPoint;
         this.corsConfigurationSource = corsConfigurationSource;
     }
 
@@ -48,9 +52,9 @@ public class SecurityConfig {
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         // REST API 서버에서 JWT 사용 시 csrf, formLogin, httpBasic 비활성화
         http
-                .csrf(csrf -> csrf.disable())
-                .formLogin(form -> form.disable())
-                .httpBasic(basic -> basic.disable())
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(corsConfigurationSource));
 
         // 인증 없이 접근 가능한 URL 설정
@@ -62,7 +66,12 @@ public class SecurityConfig {
                         .anyRequest().authenticated() // 나머지 요청은 인증 필요
                 );
 
-        //JWT 인증 필터 추가
+        // 필터에서 예외 발생 시 처리
+        http
+                .exceptionHandling(exceptions -> exceptions
+                        .authenticationEntryPoint(customAuthenticationEntryPoint));
+
+        // JWT 인증 필터 추가
         http
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/sw/momolab/server/config/SecurityConfig.java
+++ b/src/main/java/sw/momolab/server/config/SecurityConfig.java
@@ -9,17 +9,21 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
+import sw.momolab.server.filter.JwtAuthenticationFilter;
 import sw.momolab.server.service.userService.CustomUserDetailsService;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomUserDetailsService customUserDetailsService;
     private final CorsConfigurationSource corsConfigurationSource;
 
-    public SecurityConfig(CustomUserDetailsService customUserDetailsService, CorsConfigurationSource corsConfigurationSource) {
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter, CustomUserDetailsService customUserDetailsService, CorsConfigurationSource corsConfigurationSource) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
         this.customUserDetailsService = customUserDetailsService;
         this.corsConfigurationSource = corsConfigurationSource;
     }
@@ -57,6 +61,10 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .anyRequest().authenticated() // 나머지 요청은 인증 필요
                 );
+
+        //JWT 인증 필터 추가
+        http
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/sw/momolab/server/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/sw/momolab/server/filter/JwtAuthenticationFilter.java
@@ -17,7 +17,8 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-import org.springframework.web.servlet.HandlerExceptionResolver;
+import sw.momolab.server.apiPayload.code.status.ErrorStatus;
+import sw.momolab.server.apiPayload.exception.TokenHandler;
 import sw.momolab.server.service.tokenService.JwtTokenService;
 
 import java.io.IOException;
@@ -29,7 +30,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenService jwtTokenService;
     private final UserDetailsService userDetailsService;
-    private final HandlerExceptionResolver handlerExceptionResolver;
 
     private static final String HEADER_AUTHORIZATION = "Authorization";
     private static final String TOKEN_PREFIX = "Bearer ";
@@ -55,17 +55,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // 2. 토큰에서 사용자의 식별자를 추출
             userIdentifier = jwtTokenService.parseClaims(jwt).getSubject();
         } catch (ExpiredJwtException e) {
-            log.warn("만료된 JWT 토큰입니다: {}", e.getMessage());
-            handlerExceptionResolver.resolveException(request, response, null, e);
-            return;
+            throw new TokenHandler(ErrorStatus.TOKEN_EXPIRED);
         } catch (MalformedJwtException | SignatureException e) {
-            log.warn("잘못된 JWT 서명 또는 형식입니다: {}", e.getMessage());
-            handlerExceptionResolver.resolveException(request, response, null, e);
-            return;
+            throw new TokenHandler(ErrorStatus.TOKEN_INVALID);
         } catch (Exception e) {
-            log.error("기타 토큰 처리 중 예외 발생: {}", e.getMessage());
-            handlerExceptionResolver.resolveException(request, response, null, e);
-            return;
+            throw new TokenHandler(ErrorStatus.TOKEN_GENERAL_ERROR);
         }
 
         // 3. 사용자 인증 정보를 SecurityContext에 저장

--- a/src/main/java/sw/momolab/server/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/sw/momolab/server/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,94 @@
+package sw.momolab.server.filter;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+import sw.momolab.server.service.tokenService.JwtTokenService;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenService jwtTokenService;
+    private final UserDetailsService userDetailsService;
+    private final HandlerExceptionResolver handlerExceptionResolver;
+
+    private static final String HEADER_AUTHORIZATION = "Authorization";
+    private static final String TOKEN_PREFIX = "Bearer ";
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        final String authHeader = request.getHeader(HEADER_AUTHORIZATION);
+
+        // 1. JWT 토큰 추출 및 유효성 확인
+        if (authHeader == null || !authHeader.startsWith(TOKEN_PREFIX)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        final String jwt = authHeader.substring(TOKEN_PREFIX.length());
+        final String userIdentifier;
+
+        try {
+            // 2. 토큰에서 사용자의 식별자를 추출
+            userIdentifier = jwtTokenService.parseClaims(jwt).getSubject();
+        } catch (ExpiredJwtException e) {
+            log.warn("만료된 JWT 토큰입니다: {}", e.getMessage());
+            handlerExceptionResolver.resolveException(request, response, null, e);
+            return;
+        } catch (MalformedJwtException | SignatureException e) {
+            log.warn("잘못된 JWT 서명 또는 형식입니다: {}", e.getMessage());
+            handlerExceptionResolver.resolveException(request, response, null, e);
+            return;
+        } catch (Exception e) {
+            log.error("기타 토큰 처리 중 예외 발생: {}", e.getMessage());
+            handlerExceptionResolver.resolveException(request, response, null, e);
+            return;
+        }
+
+        // 3. 사용자 인증 정보를 SecurityContext에 저장
+        if (userIdentifier != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+
+            UserDetails userDetails = this.userDetailsService.loadUserByUsername(userIdentifier);
+
+            // 인증 객체 생성
+            UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                    userDetails,
+                    null,
+                    userDetails.getAuthorities()
+            );
+
+            // 요청 정보 설정
+            authToken.setDetails(
+                    new WebAuthenticationDetailsSource().buildDetails(request)
+            );
+
+            // SecurityContext에 인증 정보 저장
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/sw/momolab/server/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/sw/momolab/server/filter/JwtAuthenticationFilter.java
@@ -17,6 +17,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 import sw.momolab.server.apiPayload.code.status.ErrorStatus;
 import sw.momolab.server.apiPayload.exception.TokenHandler;
 import sw.momolab.server.service.tokenService.JwtTokenService;
@@ -30,6 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenService jwtTokenService;
     private final UserDetailsService userDetailsService;
+    private final HandlerExceptionResolver handlerExceptionResolver;
 
     private static final String HEADER_AUTHORIZATION = "Authorization";
     private static final String TOKEN_PREFIX = "Bearer ";
@@ -55,34 +57,45 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // 2. 토큰에서 사용자의 식별자를 추출
             userIdentifier = jwtTokenService.parseClaims(jwt).getSubject();
         } catch (ExpiredJwtException e) {
-            throw new TokenHandler(ErrorStatus.TOKEN_EXPIRED);
+            handlerExceptionResolver.resolveException(request, response, null,
+                    new TokenHandler(ErrorStatus.TOKEN_EXPIRED));
+            return;
         } catch (MalformedJwtException | SignatureException e) {
-            throw new TokenHandler(ErrorStatus.TOKEN_INVALID);
+            handlerExceptionResolver.resolveException(request, response, null,
+                    new TokenHandler(ErrorStatus.TOKEN_INVALID));
+            return;
         } catch (Exception e) {
-            throw new TokenHandler(ErrorStatus.TOKEN_GENERAL_ERROR);
+            handlerExceptionResolver.resolveException(request, response, null,
+                    new TokenHandler(ErrorStatus.TOKEN_GENERAL_ERROR));
+            return;
         }
 
         // 3. 사용자 인증 정보를 SecurityContext에 저장
         if (userIdentifier != null && SecurityContextHolder.getContext().getAuthentication() == null) {
 
-            UserDetails userDetails = this.userDetailsService.loadUserByUsername(userIdentifier);
+            try {
+                UserDetails userDetails = this.userDetailsService.loadUserByUsername(userIdentifier);
 
-            // 인증 객체 생성
-            UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
-                    userDetails,
-                    null,
-                    userDetails.getAuthorities()
-            );
+                // 인증 객체 생성
+                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        null,
+                        userDetails.getAuthorities()
+                );
 
-            // 요청 정보 설정
-            authToken.setDetails(
-                    new WebAuthenticationDetailsSource().buildDetails(request)
-            );
+                // 요청 정보 설정
+                authToken.setDetails(
+                        new WebAuthenticationDetailsSource().buildDetails(request)
+                );
 
-            // SecurityContext에 인증 정보 저장
-            SecurityContextHolder.getContext().setAuthentication(authToken);
+                // SecurityContext에 인증 정보 저장
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            } catch (Exception e) {
+                handlerExceptionResolver.resolveException(request, response, null,
+                        new TokenHandler(ErrorStatus.TOKEN_GENERAL_ERROR));
+                return;
+            }
         }
-
         filterChain.doFilter(request, response);
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
JWT 필터에서 발생하는 모든 예외를 Spring의 HandlerExceptionResolver로 위임하여 **@ControllerAdvice**를 통한 일관된 에러 응답 처리가 가능하도록 인증 로직을 개선했습니다.

1. 필수 의존성 주입 보장: JwtAuthenticationFilter의 handlerExceptionResolver 필드에 final 키워드를 추가하여 NullPointerException 위험을 해소하고 생성자 주입을 명확히 했습니다.

2. 예외 처리 위임 방식: ExpiredJwtException, SignatureException 등의 JWT 예외 발생 시, TokenHandler 커스텀 예외로 변환하여 handlerExceptionResolver.resolveException() 메서드를 통해 Spring MVC의 예외 처리 메커니즘으로 전달하도록 수정했습니다.

3. 오류 코드 통합: 모든 토큰 오류를 ErrorStatus 기반의 TokenHandler 예외로 캡슐화하여, @ControllerAdvice에서 일관된 JSON 응답을 생성할 수 있도록 처리 로직을 통일했습니다.

## 🔍 테스트 방법
<!-- 테스트 방법을 간략히 설명해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * JWT 토큰 만료 및 유효성 검증 기능 추가
  * 토큰 인증 오류에 대한 상세한 오류 메시지 제공
  * 인증 정보 누락 시 명확한 오류 응답 구현

* **Security**
  * 인증 요청에 대한 보안 필터 강화
  * 무단 접근 시도에 대한 개선된 예외 처리 메커니즘 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->