### PR TITLE
[Feat/#22] 토큰 재발급 로직 구현

### DIFF
--- a/src/main/java/sw/momolab/server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/sw/momolab/server/apiPayload/code/status/ErrorStatus.java
@@ -22,6 +22,10 @@ public enum ErrorStatus implements BaseErrorCode {
     TOKEN_GENERAL_ERROR(HttpStatus.UNAUTHORIZED, "AUTH_401_04", "기타 토큰 인증 오류입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_401_05", "인증 정보가 필요합니다."),
 
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_404_01", "데이터베이스에서 refreshToken을 찾을 수 없습니다."),
+
+    USER_STATUS_INACTIVE(HttpStatus.FORBIDDEN, "USER_403_01", "탈퇴한 회원입니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/sw/momolab/server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/sw/momolab/server/apiPayload/code/status/ErrorStatus.java
@@ -22,7 +22,7 @@ public enum ErrorStatus implements BaseErrorCode {
     TOKEN_GENERAL_ERROR(HttpStatus.UNAUTHORIZED, "AUTH_401_04", "기타 토큰 인증 오류입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_401_05", "인증 정보가 필요합니다."),
 
-    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_404_01", "데이터베이스에서 refreshToken을 찾을 수 없습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_401_06", "유효하지 않은 Refresh Token입니다."),
 
     USER_STATUS_INACTIVE(HttpStatus.FORBIDDEN, "USER_403_01", "탈퇴한 회원입니다."),
 

--- a/src/main/java/sw/momolab/server/converter/TokenConverter.java
+++ b/src/main/java/sw/momolab/server/converter/TokenConverter.java
@@ -7,7 +7,7 @@ import sw.momolab.server.web.dto.TokenDTO.TokenResponseDTO;
 import java.time.LocalDateTime;
 
 public class TokenConverter {
-    public static RefreshToken toRefreshTokenDTO(String refreshToken, LocalDateTime expiryDate, User user) {
+    public static RefreshToken toRefreshTokenEntity(String refreshToken, LocalDateTime expiryDate, User user) {
         return RefreshToken.builder()
                 .refreshToken(refreshToken)
                 .expiryDate(expiryDate)

--- a/src/main/java/sw/momolab/server/converter/TokenConverter.java
+++ b/src/main/java/sw/momolab/server/converter/TokenConverter.java
@@ -7,7 +7,7 @@ import sw.momolab.server.web.dto.TokenDTO.TokenResponseDTO;
 import java.time.LocalDateTime;
 
 public class TokenConverter {
-    public static RefreshToken toRefreshTokenResponseDTO(String refreshToken, LocalDateTime expiryDate, User user) {
+    public static RefreshToken toRefreshTokenDTO(String refreshToken, LocalDateTime expiryDate, User user) {
         return RefreshToken.builder()
                 .refreshToken(refreshToken)
                 .expiryDate(expiryDate)
@@ -15,7 +15,13 @@ public class TokenConverter {
                 .build();
     }
 
-    public static TokenResponseDTO.TokenDTO toTokenResponseDTO(String accessToken, String refreshToken){
+    public static TokenResponseDTO.AccessTokenDTO toAccessTokenDTO(String accessToken) {
+        return TokenResponseDTO.AccessTokenDTO.builder()
+                .accessToken(accessToken)
+                .build();
+    }
+
+    public static TokenResponseDTO.TokenDTO toTokenDTO(String accessToken, String refreshToken){
         return TokenResponseDTO.TokenDTO.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)

--- a/src/main/java/sw/momolab/server/domain/User.java
+++ b/src/main/java/sw/momolab/server/domain/User.java
@@ -44,7 +44,7 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private UserRole role;
 
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private RefreshToken refreshToken;
 
     @Builder.Default

--- a/src/main/java/sw/momolab/server/domain/User.java
+++ b/src/main/java/sw/momolab/server/domain/User.java
@@ -58,4 +58,8 @@ public class User extends BaseEntity {
     public void setRefreshToken(RefreshToken refreshTokenEntity) {
         this.refreshToken = refreshTokenEntity;
     }
+
+    public void deleteRefreshToken() {
+        this.refreshToken = null;
+    }
 }

--- a/src/main/java/sw/momolab/server/repository/RefreshTokenRepository.java
+++ b/src/main/java/sw/momolab/server/repository/RefreshTokenRepository.java
@@ -1,17 +1,10 @@
 package sw.momolab.server.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import sw.momolab.server.domain.RefreshToken;
 
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
-
-    @Modifying
-    @Query("DELETE FROM RefreshToken rt WHERE rt.id = :refreshTokenId")
-    void deleteById(@Param("refreshTokenId") Long refreshTokenId);
 }

--- a/src/main/java/sw/momolab/server/repository/RefreshTokenRepository.java
+++ b/src/main/java/sw/momolab/server/repository/RefreshTokenRepository.java
@@ -1,7 +1,17 @@
 package sw.momolab.server.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import sw.momolab.server.domain.RefreshToken;
 
+import java.util.Optional;
+
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByRefreshToken(String refreshToken);
+
+    @Modifying
+    @Query("DELETE FROM RefreshToken rt WHERE rt.id = :refreshTokenId")
+    void deleteById(@Param("refreshTokenId") Long refreshTokenId);
 }

--- a/src/main/java/sw/momolab/server/service/authService/AuthCommandServiceImpl.java
+++ b/src/main/java/sw/momolab/server/service/authService/AuthCommandServiceImpl.java
@@ -1,5 +1,6 @@
 package sw.momolab.server.service.authService;
 
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -32,6 +33,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
 
     private final JwtTokenService jwtTokenService;
     private final AuthenticationManager authenticationManager;
+    private final EntityManager entityManager;
 
     @Override
     @Transactional
@@ -43,7 +45,6 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         User user = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new AuthHandler(ErrorStatus.INVALID_CREDENTIALS));
 
-
         try {
             // 인증 수행 (비밀번호 검증)
             TokenResponseDTO.TokenDTO tokenDTO = performAuthentication(loginId, password);
@@ -51,6 +52,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
             // 인증 성공 후 로직
             setRefreshToken(tokenDTO.getRefreshToken(), user);
             user.updateLastLoginAt(LocalDateTime.now());
+
             return AuthConverter.toLoginResponseDTO(tokenDTO);
         } catch (BadCredentialsException e) {
             // 비밀번호가 일치하지 않는 경우
@@ -60,6 +62,12 @@ public class AuthCommandServiceImpl implements AuthCommandService {
 
     @Override
     public void setRefreshToken(String refreshToken, User user) {
+        if (user.getRefreshToken() != null) {
+            user.deleteRefreshToken();
+        }
+
+        entityManager.flush(); // delete 쿼리를 즉시 실행
+
         RefreshToken refreshTokenEntity = refreshTokenCommandService.createRefreshToken(refreshToken, user);
         user.setRefreshToken(refreshTokenEntity);
     }

--- a/src/main/java/sw/momolab/server/service/tokenService/JwtTokenServiceImpl.java
+++ b/src/main/java/sw/momolab/server/service/tokenService/JwtTokenServiceImpl.java
@@ -46,7 +46,7 @@ public class JwtTokenServiceImpl implements JwtTokenService {
         String accessToken = generateAccessToken(customUserDetails);
         String refreshToken = generateRefreshToken(customUserDetails);
 
-        return TokenConverter.toTokenResponseDTO(accessToken, refreshToken);
+        return TokenConverter.toTokenDTO(accessToken, refreshToken);
     }
 
     @Override

--- a/src/main/java/sw/momolab/server/service/tokenService/RefreshTokenCommandService.java
+++ b/src/main/java/sw/momolab/server/service/tokenService/RefreshTokenCommandService.java
@@ -8,6 +8,4 @@ import sw.momolab.server.web.dto.TokenDTO.TokenResponseDTO;
 public interface RefreshTokenCommandService {
     RefreshToken createRefreshToken(String refreshToken, User user);
     TokenResponseDTO.AccessTokenDTO reissueToken(TokenRequestDTO.ReissueDTO reissueDTO);
-
-    void deleteRefreshToken(RefreshToken refreshToken);
 }

--- a/src/main/java/sw/momolab/server/service/tokenService/RefreshTokenCommandService.java
+++ b/src/main/java/sw/momolab/server/service/tokenService/RefreshTokenCommandService.java
@@ -2,7 +2,12 @@ package sw.momolab.server.service.tokenService;
 
 import sw.momolab.server.domain.User;
 import sw.momolab.server.domain.RefreshToken;
+import sw.momolab.server.web.dto.TokenDTO.TokenRequestDTO;
+import sw.momolab.server.web.dto.TokenDTO.TokenResponseDTO;
 
 public interface RefreshTokenCommandService {
     RefreshToken createRefreshToken(String refreshToken, User user);
+    TokenResponseDTO.AccessTokenDTO reissueToken(TokenRequestDTO.ReissueDTO reissueDTO);
+
+    void deleteRefreshToken(RefreshToken refreshToken);
 }

--- a/src/main/java/sw/momolab/server/service/tokenService/RefreshTokenCommandServiceImpl.java
+++ b/src/main/java/sw/momolab/server/service/tokenService/RefreshTokenCommandServiceImpl.java
@@ -2,10 +2,19 @@ package sw.momolab.server.service.tokenService;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sw.momolab.server.apiPayload.code.status.ErrorStatus;
+import sw.momolab.server.apiPayload.exception.AuthHandler;
+import sw.momolab.server.apiPayload.exception.UserHandler;
 import sw.momolab.server.converter.TokenConverter;
+import sw.momolab.server.domain.CustomUserDetails;
 import sw.momolab.server.domain.RefreshToken;
 import sw.momolab.server.domain.User;
+import sw.momolab.server.domain.enums.UserStatus;
 import sw.momolab.server.repository.RefreshTokenRepository;
+import sw.momolab.server.service.userService.CustomUserDetailsService;
+import sw.momolab.server.web.dto.TokenDTO.TokenRequestDTO;
+import sw.momolab.server.web.dto.TokenDTO.TokenResponseDTO;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -17,13 +26,44 @@ public class RefreshTokenCommandServiceImpl implements RefreshTokenCommandServic
 
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtTokenService jwtTokenService;
+    private final CustomUserDetailsService customUserDetailsService;
 
     @Override
     public RefreshToken createRefreshToken(String refreshToken, User user) {
         Date expiryDate = jwtTokenService.parseClaims(refreshToken).getExpiration();
         LocalDateTime localDateTime = LocalDateTime.ofInstant(expiryDate.toInstant(), ZoneId.systemDefault());
 
-        RefreshToken refreshTokenEntity = TokenConverter.toRefreshTokenResponseDTO(refreshToken, localDateTime, user);
+        RefreshToken refreshTokenEntity = TokenConverter.toRefreshTokenDTO(refreshToken, localDateTime, user);
         return refreshTokenRepository.save(refreshTokenEntity);
+    }
+
+    @Transactional(noRollbackFor = AuthHandler.class)
+    @Override
+    public TokenResponseDTO.AccessTokenDTO reissueToken(TokenRequestDTO.ReissueDTO reissueDTO) {
+        RefreshToken storedRefreshToken = refreshTokenRepository.findByRefreshToken(reissueDTO.getRefreshToken()) //요청한 refresh token 이 database 에 존재하는지 확인
+                .orElseThrow(() -> new AuthHandler(ErrorStatus.REFRESH_TOKEN_NOT_FOUND));
+
+        if (storedRefreshToken.getUser() == null)
+            throw new AuthHandler(ErrorStatus.TOKEN_INVALID);
+
+        if (storedRefreshToken.getUser().getStatus() == UserStatus.INACTIVE)   //탈퇴한 회원은 accessToken 재발급 하지 않음
+            throw new UserHandler(ErrorStatus.USER_STATUS_INACTIVE);
+
+        if (storedRefreshToken.getExpiryDate().isBefore(LocalDateTime.now())) { //refresh token 이 만료되었는지 확인
+            storedRefreshToken.getUser().deleteRefreshToken();
+            throw new AuthHandler(ErrorStatus.TOKEN_EXPIRED);
+        }
+
+        CustomUserDetails customUserDetails = customUserDetailsService.loadUserByUsername(storedRefreshToken.getUser().getLoginId());
+
+        String accessToken = jwtTokenService.generateAccessToken(customUserDetails); //액세스 토큰 생성
+
+        return TokenConverter.toAccessTokenDTO(accessToken);
+    }
+
+    @Override
+    @Transactional
+    public void deleteRefreshToken(RefreshToken refreshToken) {
+        refreshTokenRepository.delete(refreshToken);
     }
 }

--- a/src/main/java/sw/momolab/server/service/tokenService/RefreshTokenCommandServiceImpl.java
+++ b/src/main/java/sw/momolab/server/service/tokenService/RefreshTokenCommandServiceImpl.java
@@ -44,6 +44,13 @@ public class RefreshTokenCommandServiceImpl implements RefreshTokenCommandServic
             throw new AuthHandler(ErrorStatus.TOKEN_INVALID);
         }
 
+        // JWT 서명 및 기본 클레임 검증
+        try {
+            jwtTokenService.parseClaims(reissueDTO.getRefreshToken());
+        } catch (Exception e) {
+            throw new AuthHandler(ErrorStatus.TOKEN_INVALID);
+        }
+
         RefreshToken storedRefreshToken = refreshTokenRepository.findByRefreshToken(reissueDTO.getRefreshToken())
                 .orElseThrow(() -> new AuthHandler(ErrorStatus.REFRESH_TOKEN_NOT_FOUND));
 

--- a/src/main/java/sw/momolab/server/service/tokenService/RefreshTokenCommandServiceImpl.java
+++ b/src/main/java/sw/momolab/server/service/tokenService/RefreshTokenCommandServiceImpl.java
@@ -37,9 +37,13 @@ public class RefreshTokenCommandServiceImpl implements RefreshTokenCommandServic
         return refreshTokenRepository.save(refreshTokenEntity);
     }
 
-    @Transactional(noRollbackFor = AuthHandler.class)
+    @Transactional(readOnly = true)
     @Override
     public TokenResponseDTO.AccessTokenDTO reissueToken(TokenRequestDTO.ReissueDTO reissueDTO) {
+        if (reissueDTO == null || reissueDTO.getRefreshToken() == null || reissueDTO.getRefreshToken().isBlank()) {
+            throw new AuthHandler(ErrorStatus.TOKEN_INVALID);
+        }
+
         RefreshToken storedRefreshToken = refreshTokenRepository.findByRefreshToken(reissueDTO.getRefreshToken())
                 .orElseThrow(() -> new AuthHandler(ErrorStatus.REFRESH_TOKEN_NOT_FOUND));
 
@@ -50,7 +54,6 @@ public class RefreshTokenCommandServiceImpl implements RefreshTokenCommandServic
             throw new UserHandler(ErrorStatus.USER_STATUS_INACTIVE);
 
         if (storedRefreshToken.getExpiryDate().isBefore(LocalDateTime.now())) {
-            storedRefreshToken.getUser().deleteRefreshToken();
             throw new AuthHandler(ErrorStatus.TOKEN_EXPIRED);
         }
 

--- a/src/main/java/sw/momolab/server/service/tokenService/RefreshTokenCommandServiceImpl.java
+++ b/src/main/java/sw/momolab/server/service/tokenService/RefreshTokenCommandServiceImpl.java
@@ -40,23 +40,22 @@ public class RefreshTokenCommandServiceImpl implements RefreshTokenCommandServic
     @Transactional(noRollbackFor = AuthHandler.class)
     @Override
     public TokenResponseDTO.AccessTokenDTO reissueToken(TokenRequestDTO.ReissueDTO reissueDTO) {
-        RefreshToken storedRefreshToken = refreshTokenRepository.findByRefreshToken(reissueDTO.getRefreshToken()) //요청한 refresh token 이 database 에 존재하는지 확인
+        RefreshToken storedRefreshToken = refreshTokenRepository.findByRefreshToken(reissueDTO.getRefreshToken())
                 .orElseThrow(() -> new AuthHandler(ErrorStatus.REFRESH_TOKEN_NOT_FOUND));
 
         if (storedRefreshToken.getUser() == null)
             throw new AuthHandler(ErrorStatus.TOKEN_INVALID);
 
-        if (storedRefreshToken.getUser().getStatus() == UserStatus.INACTIVE)   //탈퇴한 회원은 accessToken 재발급 하지 않음
+        if (storedRefreshToken.getUser().getStatus() == UserStatus.INACTIVE)
             throw new UserHandler(ErrorStatus.USER_STATUS_INACTIVE);
 
-        if (storedRefreshToken.getExpiryDate().isBefore(LocalDateTime.now())) { //refresh token 이 만료되었는지 확인
+        if (storedRefreshToken.getExpiryDate().isBefore(LocalDateTime.now())) {
             storedRefreshToken.getUser().deleteRefreshToken();
             throw new AuthHandler(ErrorStatus.TOKEN_EXPIRED);
         }
 
         CustomUserDetails customUserDetails = customUserDetailsService.loadUserByUsername(storedRefreshToken.getUser().getLoginId());
-
-        String accessToken = jwtTokenService.generateAccessToken(customUserDetails); //액세스 토큰 생성
+        String accessToken = jwtTokenService.generateAccessToken(customUserDetails); // at 생성
 
         return TokenConverter.toAccessTokenDTO(accessToken);
     }

--- a/src/main/java/sw/momolab/server/service/tokenService/RefreshTokenCommandServiceImpl.java
+++ b/src/main/java/sw/momolab/server/service/tokenService/RefreshTokenCommandServiceImpl.java
@@ -33,7 +33,7 @@ public class RefreshTokenCommandServiceImpl implements RefreshTokenCommandServic
         Date expiryDate = jwtTokenService.parseClaims(refreshToken).getExpiration();
         LocalDateTime localDateTime = LocalDateTime.ofInstant(expiryDate.toInstant(), ZoneId.systemDefault());
 
-        RefreshToken refreshTokenEntity = TokenConverter.toRefreshTokenDTO(refreshToken, localDateTime, user);
+        RefreshToken refreshTokenEntity = TokenConverter.toRefreshTokenEntity(refreshToken, localDateTime, user);
         return refreshTokenRepository.save(refreshTokenEntity);
     }
 
@@ -61,11 +61,5 @@ public class RefreshTokenCommandServiceImpl implements RefreshTokenCommandServic
         String accessToken = jwtTokenService.generateAccessToken(customUserDetails); // at 생성
 
         return TokenConverter.toAccessTokenDTO(accessToken);
-    }
-
-    @Override
-    @Transactional
-    public void deleteRefreshToken(RefreshToken refreshToken) {
-        refreshTokenRepository.delete(refreshToken);
     }
 }

--- a/src/main/java/sw/momolab/server/web/controller/AuthController.java
+++ b/src/main/java/sw/momolab/server/web/controller/AuthController.java
@@ -10,8 +10,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import sw.momolab.server.apiPayload.ApiResponse;
 import sw.momolab.server.service.authService.AuthCommandService;
+import sw.momolab.server.service.tokenService.RefreshTokenCommandService;
 import sw.momolab.server.web.dto.AuthDTO.AuthRequestDTO;
 import sw.momolab.server.web.dto.AuthDTO.AuthResponseDTO;
+import sw.momolab.server.web.dto.TokenDTO.TokenRequestDTO;
+import sw.momolab.server.web.dto.TokenDTO.TokenResponseDTO;
 
 @Tag(name = "auth", description = "인증 관련 API")
 @RestController
@@ -20,11 +23,19 @@ import sw.momolab.server.web.dto.AuthDTO.AuthResponseDTO;
 public class AuthController {
 
     private final AuthCommandService authCommandService;
+    private final RefreshTokenCommandService refreshTokenCommandService;
 
     @PostMapping("/login")
     @Operation(summary = "로그인 인증 API", description = "등록한 계정의 아이디와 비밀번호가 일치하면 로그인에 성공합니다.")
     public ApiResponse<AuthResponseDTO.LoginResponseDTO> login(@RequestBody @Valid AuthRequestDTO.LoginRequestDTO request) {
         AuthResponseDTO.LoginResponseDTO result = authCommandService.login(request);
+        return ApiResponse.onSuccess(result);
+    }
+
+    @PostMapping("/reissue")
+    @Operation(summary = "토큰 재발급 API", description = "refreshToken 값을 넘겨서 accessToken을 재발급받습니다.")
+    public ApiResponse<TokenResponseDTO.AccessTokenDTO> reissueToken(@RequestBody @Valid TokenRequestDTO.ReissueDTO reissueDTO) {
+        TokenResponseDTO.AccessTokenDTO result = refreshTokenCommandService.reissueToken(reissueDTO);
         return ApiResponse.onSuccess(result);
     }
 }

--- a/src/main/java/sw/momolab/server/web/dto/TokenDTO/TokenRequestDTO.java
+++ b/src/main/java/sw/momolab/server/web/dto/TokenDTO/TokenRequestDTO.java
@@ -1,0 +1,19 @@
+package sw.momolab.server.web.dto.TokenDTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class TokenRequestDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(title = "토큰 재발급 요청 dto")
+    public static class ReissueDTO {
+        @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJ...")
+        private String refreshToken;
+    }
+}

--- a/src/main/java/sw/momolab/server/web/dto/TokenDTO/TokenRequestDTO.java
+++ b/src/main/java/sw/momolab/server/web/dto/TokenDTO/TokenRequestDTO.java
@@ -1,6 +1,7 @@
 package sw.momolab.server.web.dto.TokenDTO;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +15,7 @@ public class TokenRequestDTO {
     @Schema(title = "토큰 재발급 요청 dto")
     public static class ReissueDTO {
         @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJ...")
+        @NotBlank(message = "리프레시 토큰은 필수 입력 항목입니다.")
         private String refreshToken;
     }
 }

--- a/src/main/java/sw/momolab/server/web/dto/TokenDTO/TokenResponseDTO.java
+++ b/src/main/java/sw/momolab/server/web/dto/TokenDTO/TokenResponseDTO.java
@@ -18,4 +18,14 @@ public class TokenResponseDTO {
         @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJ...")
         private String refreshToken;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(title = "액세스 토큰 발급 응답 dto")
+    public static class AccessTokenDTO {
+        @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJ...")
+        private String accessToken;
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용
토큰 재발급 로직을 구현하였으며, 재로그인 시 rt가 즉시 제거되도록 작업하였습니다. (orphanRemoval 속성 사용)

## 🔍 테스트 방법
<!-- 테스트 방법을 간략히 설명해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 리프레시 토큰으로 액세스 토큰을 재발급하는 신규 API 및 액세스 토큰 응답 DTO 추가
  * 리프레시 토큰 조회 및 재발급 흐름(토큰 재발급 엔드포인트) 추가

* **Bug Fixes**
  * 기존 리프레시 토큰 삭제로 중복 발급 방지 및 안정성 개선
  * 유효하지 않은 리프레시 토큰과 탈퇴 회원에 대한 명확한 오류 응답 추가

* **Refactor**
  * 토큰 생성·변환 흐름 및 관련 DTO 구조 정리로 가독성·유지보수성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->