### PR TITLE
[FEAT/#27] 캘린더 조회 api 구현

### DIFF
--- a/src/main/java/sw/momolab/server/converter/RecordConverter.java
+++ b/src/main/java/sw/momolab/server/converter/RecordConverter.java
@@ -1,0 +1,14 @@
+package sw.momolab.server.converter;
+
+import sw.momolab.server.web.dto.RecordDTO.RecordResponseDTO;
+
+import java.time.LocalDate;
+
+public class RecordConverter {
+    public static RecordResponseDTO.CalendarResponseDTO toCalendarResponseDTO(LocalDate date, boolean hasSchedule) {
+        return RecordResponseDTO.CalendarResponseDTO.builder()
+                .date(date)
+                .hasSchedule(hasSchedule)
+                .build();
+    }
+}

--- a/src/main/java/sw/momolab/server/domain/Record.java
+++ b/src/main/java/sw/momolab/server/domain/Record.java
@@ -65,6 +65,10 @@ public class Record extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String notes;
 
+    // GCS에 저장된 OCR 이미지 파일 경로
+    @Column
+    private String gcsPath;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;

--- a/src/main/java/sw/momolab/server/domain/Record.java
+++ b/src/main/java/sw/momolab/server/domain/Record.java
@@ -66,7 +66,7 @@ public class Record extends BaseEntity {
     private String notes;
 
     // GCS에 저장된 OCR 이미지 파일 경로
-    @Column
+    @Column(length = 512)
     private String gcsPath;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/sw/momolab/server/repository/RecordRepository.java
+++ b/src/main/java/sw/momolab/server/repository/RecordRepository.java
@@ -1,0 +1,19 @@
+package sw.momolab.server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import sw.momolab.server.domain.Record;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+public interface RecordRepository extends JpaRepository<Record, Long> {
+
+    // 특정 기간동안 기록 일정이 있는 모든 날짜 조회
+    @Query("SELECT DISTINCT r.recordDate FROM Record r WHERE r.user.id = :userId AND r.recordDate BETWEEN :startDate AND :endDate")
+    Set<LocalDate> findDistinctRecordDatesByUserIdAndDateRange(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate);
+}

--- a/src/main/java/sw/momolab/server/service/recordService/RecordQueryService.java
+++ b/src/main/java/sw/momolab/server/service/recordService/RecordQueryService.java
@@ -1,0 +1,10 @@
+package sw.momolab.server.service.recordService;
+
+import sw.momolab.server.web.dto.RecordDTO.RecordResponseDTO;
+
+import java.time.YearMonth;
+import java.util.List;
+
+public interface RecordQueryService {
+    List<RecordResponseDTO.CalendarResponseDTO> getMonthlyRecordStatus(Long userId, YearMonth yearMonth);
+}

--- a/src/main/java/sw/momolab/server/service/recordService/RecordQueryServiceImpl.java
+++ b/src/main/java/sw/momolab/server/service/recordService/RecordQueryServiceImpl.java
@@ -1,0 +1,49 @@
+package sw.momolab.server.service.recordService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sw.momolab.server.converter.RecordConverter;
+import sw.momolab.server.repository.RecordRepository;
+import sw.momolab.server.web.dto.RecordDTO.RecordResponseDTO;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecordQueryServiceImpl implements RecordQueryService {
+
+    private final RecordRepository recordRepository;
+
+    @Override
+    public List<RecordResponseDTO.CalendarResponseDTO> getMonthlyRecordStatus(Long userId, YearMonth yearMonth) {
+
+        // 해당 월의 시작 날짜와 끝 날짜를 계산
+        LocalDate startDate = yearMonth.atDay(1);
+        LocalDate endDate = yearMonth.atEndOfMonth();
+
+        Set<LocalDate> recordedDates = recordRepository.findDistinctRecordDatesByUserIdAndDateRange(userId, startDate, endDate);
+        Set<String> recordedDateStrings = recordedDates.stream()
+                .map(LocalDate::toString)
+                .collect(Collectors.toSet());
+
+        // 해당 월의 모든 날짜를 순회하며 DTO를 생성
+        int daysInMonth = yearMonth.lengthOfMonth();
+
+        return IntStream.rangeClosed(1, daysInMonth)
+                .mapToObj(day -> {
+                    LocalDate date = yearMonth.atDay(day);
+                    // 기록이 존재하는지 확인
+                    boolean hasSchedule = recordedDateStrings.contains(date.toString());
+
+                    return RecordConverter.toCalendarResponseDTO(date, hasSchedule);
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/sw/momolab/server/service/recordService/RecordQueryServiceImpl.java
+++ b/src/main/java/sw/momolab/server/service/recordService/RecordQueryServiceImpl.java
@@ -29,9 +29,6 @@ public class RecordQueryServiceImpl implements RecordQueryService {
         LocalDate endDate = yearMonth.atEndOfMonth();
 
         Set<LocalDate> recordedDates = recordRepository.findDistinctRecordDatesByUserIdAndDateRange(userId, startDate, endDate);
-        Set<String> recordedDateStrings = recordedDates.stream()
-                .map(LocalDate::toString)
-                .collect(Collectors.toSet());
 
         // 해당 월의 모든 날짜를 순회하며 DTO를 생성
         int daysInMonth = yearMonth.lengthOfMonth();
@@ -40,7 +37,7 @@ public class RecordQueryServiceImpl implements RecordQueryService {
                 .mapToObj(day -> {
                     LocalDate date = yearMonth.atDay(day);
                     // 기록이 존재하는지 확인
-                    boolean hasSchedule = recordedDateStrings.contains(date.toString());
+                    boolean hasSchedule = recordedDates.contains(date);
 
                     return RecordConverter.toCalendarResponseDTO(date, hasSchedule);
                 })

--- a/src/main/java/sw/momolab/server/web/controller/RecordController.java
+++ b/src/main/java/sw/momolab/server/web/controller/RecordController.java
@@ -1,0 +1,39 @@
+package sw.momolab.server.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import sw.momolab.server.apiPayload.ApiResponse;
+import sw.momolab.server.domain.CustomUserDetails;
+import sw.momolab.server.service.recordService.RecordQueryService;
+import sw.momolab.server.web.dto.RecordDTO.RecordResponseDTO;
+
+import java.time.YearMonth;
+import java.util.List;
+
+@Tag(name = "records", description = "기록 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/records")
+public class RecordController {
+
+    private final RecordQueryService recordQueryService;
+
+    @GetMapping("/calendar")
+    @Operation(summary = "캘린더 조회 API", description = "환자의 기록 여부를 캘린더에서 조회합니다.")
+    public ApiResponse<List<RecordResponseDTO.CalendarResponseDTO>> getMonthlyCalendar(@AuthenticationPrincipal CustomUserDetails user,
+                                                                                       @Parameter(description = "기록 연도", example = "2025")@RequestParam int year,
+                                                                                       @Parameter(description = "기록 달", example = "11")@RequestParam int month) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        Long userId = user.getId();
+
+        List<RecordResponseDTO.CalendarResponseDTO> result = recordQueryService.getMonthlyRecordStatus(userId, yearMonth);
+        return ApiResponse.onSuccess(result);
+    }
+}

--- a/src/main/java/sw/momolab/server/web/controller/RecordController.java
+++ b/src/main/java/sw/momolab/server/web/controller/RecordController.java
@@ -31,11 +31,10 @@ public class RecordController {
 
     @GetMapping("/calendar")
     @Operation(summary = "캘린더 조회 API", description = "환자의 기록 여부를 캘린더에서 조회합니다.")
-    public ApiResponse<List<RecordResponseDTO.CalendarResponseDTO>> getMonthlyCalendar(@AuthenticationPrincipal CustomUserDetails user,
-                                                                                       @Parameter(description = "기록 연도", example = "2025")@RequestParam @Min(2000) @Max(2100) int year,
+    public ApiResponse<List<RecordResponseDTO.CalendarResponseDTO>> getMonthlyCalendar(@AuthenticationPrincipal(expression = "id") Long userId,
+                                                                                       @Parameter(description = "기록 연도", example = "2025")@RequestParam @Min(1900) @Max(2100) int year,
                                                                                        @Parameter(description = "기록 달", example = "11")@RequestParam @Min(1) @Max(12) int month) {
         YearMonth yearMonth = YearMonth.of(year, month);
-        Long userId = user.getId();
 
         List<RecordResponseDTO.CalendarResponseDTO> result = recordQueryService.getMonthlyRecordStatus(userId, yearMonth);
         return ApiResponse.onSuccess(result);

--- a/src/main/java/sw/momolab/server/web/controller/RecordController.java
+++ b/src/main/java/sw/momolab/server/web/controller/RecordController.java
@@ -3,8 +3,11 @@ package sw.momolab.server.web.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -19,6 +22,7 @@ import java.util.List;
 
 @Tag(name = "records", description = "기록 관련 API")
 @RestController
+@Validated
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/records")
 public class RecordController {
@@ -28,8 +32,8 @@ public class RecordController {
     @GetMapping("/calendar")
     @Operation(summary = "캘린더 조회 API", description = "환자의 기록 여부를 캘린더에서 조회합니다.")
     public ApiResponse<List<RecordResponseDTO.CalendarResponseDTO>> getMonthlyCalendar(@AuthenticationPrincipal CustomUserDetails user,
-                                                                                       @Parameter(description = "기록 연도", example = "2025")@RequestParam int year,
-                                                                                       @Parameter(description = "기록 달", example = "11")@RequestParam int month) {
+                                                                                       @Parameter(description = "기록 연도", example = "2025")@RequestParam @Min(2000) @Max(2100) int year,
+                                                                                       @Parameter(description = "기록 달", example = "11")@RequestParam @Min(1) @Max(12) int month) {
         YearMonth yearMonth = YearMonth.of(year, month);
         Long userId = user.getId();
 

--- a/src/main/java/sw/momolab/server/web/controller/RecordController.java
+++ b/src/main/java/sw/momolab/server/web/controller/RecordController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import sw.momolab.server.apiPayload.ApiResponse;
-import sw.momolab.server.domain.CustomUserDetails;
 import sw.momolab.server.service.recordService.RecordQueryService;
 import sw.momolab.server.web.dto.RecordDTO.RecordResponseDTO;
 
@@ -32,8 +31,8 @@ public class RecordController {
     @GetMapping("/calendar")
     @Operation(summary = "캘린더 조회 API", description = "환자의 기록 여부를 캘린더에서 조회합니다.")
     public ApiResponse<List<RecordResponseDTO.CalendarResponseDTO>> getMonthlyCalendar(@AuthenticationPrincipal(expression = "id") Long userId,
-                                                                                       @Parameter(description = "기록 연도", example = "2025")@RequestParam @Min(1900) @Max(2100) int year,
-                                                                                       @Parameter(description = "기록 달", example = "11")@RequestParam @Min(1) @Max(12) int month) {
+                                                                                       @Parameter(description = "기록 연도", example = "2025")@RequestParam @Min(value = 1900, message = "_BAD_REQUEST") @Max(value = 2100, message = "_BAD_REQUEST") int year,
+                                                                                       @Parameter(description = "기록 달", example = "11")@RequestParam @Min(value = 1, message = "_BAD_REQUEST") @Max(value = 12, message = "_BAD_REQUEST") int month) {
         YearMonth yearMonth = YearMonth.of(year, month);
 
         List<RecordResponseDTO.CalendarResponseDTO> result = recordQueryService.getMonthlyRecordStatus(userId, yearMonth);

--- a/src/main/java/sw/momolab/server/web/dto/RecordDTO/RecordResponseDTO.java
+++ b/src/main/java/sw/momolab/server/web/dto/RecordDTO/RecordResponseDTO.java
@@ -1,5 +1,6 @@
 package sw.momolab.server.web.dto.RecordDTO;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,9 +16,10 @@ public class RecordResponseDTO {
     public static class CalendarResponseDTO{
 
         @Schema(description = "날짜")
+        @JsonFormat(pattern = "yyyy-MM-dd")
         private LocalDate date;
 
         @Schema(description = "기록 여부", example = "true")
-        private Boolean hasSchedule;
+        private boolean hasSchedule;
     }
 }

--- a/src/main/java/sw/momolab/server/web/dto/RecordDTO/RecordResponseDTO.java
+++ b/src/main/java/sw/momolab/server/web/dto/RecordDTO/RecordResponseDTO.java
@@ -1,0 +1,23 @@
+package sw.momolab.server.web.dto.RecordDTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+public class RecordResponseDTO {
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(title = "캘린더 응답 dto")
+    public static class CalendarResponseDTO{
+
+        @Schema(description = "날짜")
+        private LocalDate date;
+
+        @Schema(description = "기록 여부", example = "true")
+        private Boolean hasSchedule;
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
아래와 같은 형식으로 결과가 반환되도록 하였습니다.
프론트에서 연동 시, hasSchedule이 true인 날짜 부분에 아이콘을 표시할 예정입니다.
hasSchedule: true -> 기록 존재 | false -> 기록 미존재
```java
    {
      "date": "2025-11-12",
      "hasSchedule": false
    },
    {
      "date": "2025-11-13",
      "hasSchedule": true
    },
``` 

## 🔍 테스트 방법
<!-- 테스트 방법을 간략히 설명해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 월별 기록 상태 조회용 캘린더 API 추가 — 특정 연월의 모든 날짜에 대해 기록 여부를 반환합니다.
  * 캘린더 응답에 날짜(date, yyyy‑MM‑dd)와 기록 여부(hasSchedule) 제공.
  * 기록 항목에 OCR 이미지 경로 저장 지원이 추가되어 이미지 연동이 가능해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->