### PR TITLE
[FEAT/#29] 로그아웃 api 구현

### DIFF
--- a/src/main/java/sw/momolab/server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/sw/momolab/server/apiPayload/code/status/ErrorStatus.java
@@ -24,7 +24,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_401_06", "유효하지 않은 Refresh Token입니다."),
 
-    USER_STATUS_INACTIVE(HttpStatus.FORBIDDEN, "USER_403_01", "탈퇴한 회원입니다."),
+    USER_STATUS_INACTIVE(HttpStatus.FORBIDDEN, "USER_403_01", "탈퇴한 사용자입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_404_01", "사용자를 찾을 수 없습니다."),
+
 
     ;
 

--- a/src/main/java/sw/momolab/server/config/SecurityConfig.java
+++ b/src/main/java/sw/momolab/server/config/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/actuator/**").permitAll()
-                        .requestMatchers("/api/v1/auth/**").permitAll()
+                        .requestMatchers("/api/v1/auth/login", "/api/v1/auth/reissue").permitAll()
                         .anyRequest().authenticated() // 나머지 요청은 인증 필요
                 );
 

--- a/src/main/java/sw/momolab/server/service/authService/AuthCommandService.java
+++ b/src/main/java/sw/momolab/server/service/authService/AuthCommandService.java
@@ -9,4 +9,5 @@ public interface AuthCommandService {
     AuthResponseDTO.LoginResponseDTO login(AuthRequestDTO.LoginRequestDTO request);
     TokenResponseDTO.TokenDTO performAuthentication(String loginId, String password);
     void setRefreshToken(String refreshToken, User user);
+    void logout(Long userId);
 }

--- a/src/main/java/sw/momolab/server/service/authService/AuthCommandServiceImpl.java
+++ b/src/main/java/sw/momolab/server/service/authService/AuthCommandServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sw.momolab.server.apiPayload.code.status.ErrorStatus;
 import sw.momolab.server.apiPayload.exception.AuthHandler;
+import sw.momolab.server.apiPayload.exception.UserHandler;
 import sw.momolab.server.converter.AuthConverter;
 import sw.momolab.server.domain.CustomUserDetails;
 import sw.momolab.server.domain.RefreshToken;
@@ -87,10 +88,10 @@ public class AuthCommandServiceImpl implements AuthCommandService {
 
     @Override
     @Transactional
-    public void logout(Long userId){
+    public void logout(Long userId) {
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new AuthHandler(ErrorStatus.INVALID_CREDENTIALS));
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         // RefreshToken이 있는 경우에만 삭제 처리
         if (user.getRefreshToken() != null) {

--- a/src/main/java/sw/momolab/server/service/authService/AuthCommandServiceImpl.java
+++ b/src/main/java/sw/momolab/server/service/authService/AuthCommandServiceImpl.java
@@ -84,4 +84,21 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         //인증 성공 시 JWT 토큰 생성
         return jwtTokenService.generateToken((CustomUserDetails) authentication.getPrincipal());
     }
+
+    @Override
+    @Transactional
+    public void logout(Long userId){
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AuthHandler(ErrorStatus.INVALID_CREDENTIALS));
+
+        // RefreshToken이 있는 경우에만 삭제 처리
+        if (user.getRefreshToken() != null) {
+            RefreshToken refreshToken = user.getRefreshToken();
+            user.deleteRefreshToken();
+            userRepository.save(user);
+
+            refreshTokenCommandService.deleteRefreshToken(refreshToken);
+        }
+    }
 }

--- a/src/main/java/sw/momolab/server/service/authService/AuthCommandServiceImpl.java
+++ b/src/main/java/sw/momolab/server/service/authService/AuthCommandServiceImpl.java
@@ -97,8 +97,6 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         if (user.getRefreshToken() != null) {
             RefreshToken refreshToken = user.getRefreshToken();
             user.deleteRefreshToken();
-            userRepository.save(user);
-
             refreshTokenCommandService.deleteRefreshToken(refreshToken);
         }
     }

--- a/src/main/java/sw/momolab/server/service/tokenService/RefreshTokenCommandService.java
+++ b/src/main/java/sw/momolab/server/service/tokenService/RefreshTokenCommandService.java
@@ -8,4 +8,5 @@ import sw.momolab.server.web.dto.TokenDTO.TokenResponseDTO;
 public interface RefreshTokenCommandService {
     RefreshToken createRefreshToken(String refreshToken, User user);
     TokenResponseDTO.AccessTokenDTO reissueToken(TokenRequestDTO.ReissueDTO reissueDTO);
+    void deleteRefreshToken(RefreshToken refreshToken);
 }

--- a/src/main/java/sw/momolab/server/service/tokenService/RefreshTokenCommandServiceImpl.java
+++ b/src/main/java/sw/momolab/server/service/tokenService/RefreshTokenCommandServiceImpl.java
@@ -69,4 +69,10 @@ public class RefreshTokenCommandServiceImpl implements RefreshTokenCommandServic
 
         return TokenConverter.toAccessTokenDTO(accessToken);
     }
+
+    @Override
+    @Transactional
+    public void deleteRefreshToken(RefreshToken refreshToken) {
+        refreshTokenRepository.delete(refreshToken);
+    }
 }

--- a/src/main/java/sw/momolab/server/web/controller/AuthController.java
+++ b/src/main/java/sw/momolab/server/web/controller/AuthController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,5 +38,12 @@ public class AuthController {
     public ApiResponse<TokenResponseDTO.AccessTokenDTO> reissueToken(@RequestBody @Valid TokenRequestDTO.ReissueDTO reissueDTO) {
         TokenResponseDTO.AccessTokenDTO result = refreshTokenCommandService.reissueToken(reissueDTO);
         return ApiResponse.onSuccess(result);
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃 API", description = "사용자의 refreshToken 값을 삭제합니다.")
+    public ApiResponse<Void> logout(@AuthenticationPrincipal(expression = "id") Long userId) {
+        authCommandService.logout(userId);
+        return ApiResponse.onSuccess();
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
로그인한 상태에서 로그아웃 api를 테스트하면 사용자의 refreshToken을 null로 설정합니다.

## 🔍 테스트 방법
<!-- 테스트 방법을 간략히 설명해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 로그아웃 API 추가: 사용자가 로그아웃하면 발급된 리프레시 토큰이 삭제되어 세션이 종료됩니다.

* **버그 수정 / 메시지 변경**
  * 사용자 관련 오류 메시지 추가·수정(사용자 미존재, 탈퇴한 사용자 안내 등).

* **보안/접근성 변경**
  * 인증 엔드포인트 접근 범위 축소: 일부 인증 경로는 이제 인증 후에만 이용 가능합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->