### PR TITLE
[FEAT/#31] 마이페이지 조회 api 구현

### DIFF
--- a/src/main/java/sw/momolab/server/converter/UserConverter.java
+++ b/src/main/java/sw/momolab/server/converter/UserConverter.java
@@ -1,0 +1,16 @@
+package sw.momolab.server.converter;
+
+import sw.momolab.server.domain.User;
+import sw.momolab.server.web.dto.UserDTO.UserResponseDTO;
+
+import java.time.LocalDate;
+
+public class UserConverter {
+    public static UserResponseDTO.MyPageDTO toMyPageDTO(User user, LocalDate firstRecordDate, String dPlusPeriod) {
+        return UserResponseDTO.MyPageDTO.builder()
+                .loginId(user.getLoginId())
+                .recordStartDate(firstRecordDate)
+                .recordPeriod(dPlusPeriod)
+                .build();
+    }
+}

--- a/src/main/java/sw/momolab/server/repository/RecordRepository.java
+++ b/src/main/java/sw/momolab/server/repository/RecordRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.query.Param;
 import sw.momolab.server.domain.Record;
 
 import java.time.LocalDate;
+import java.util.Optional;
 import java.util.Set;
 
 public interface RecordRepository extends JpaRepository<Record, Long> {
@@ -16,4 +17,8 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
             @Param("userId") Long userId,
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate);
+
+    // 처음 기록 작성 날짜 조회
+    @Query("SELECT MIN(r.recordDate) FROM Record r WHERE r.user.id = :userId")
+    Optional<LocalDate> findFirstRecordDateByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/sw/momolab/server/service/userService/UserQueryService.java
+++ b/src/main/java/sw/momolab/server/service/userService/UserQueryService.java
@@ -3,6 +3,5 @@ package sw.momolab.server.service.userService;
 import sw.momolab.server.web.dto.UserDTO.UserResponseDTO;
 
 public interface UserQueryService {
-    String getRecordDate(Long userId);
     UserResponseDTO.MyPageDTO getMyPage(Long userId);
 }

--- a/src/main/java/sw/momolab/server/service/userService/UserQueryService.java
+++ b/src/main/java/sw/momolab/server/service/userService/UserQueryService.java
@@ -1,0 +1,8 @@
+package sw.momolab.server.service.userService;
+
+import sw.momolab.server.web.dto.UserDTO.UserResponseDTO;
+
+public interface UserQueryService {
+    String getRecordDate(Long userId);
+    UserResponseDTO.MyPageDTO getMyPage(Long userId);
+}

--- a/src/main/java/sw/momolab/server/service/userService/UserQueryServiceImpl.java
+++ b/src/main/java/sw/momolab/server/service/userService/UserQueryServiceImpl.java
@@ -2,13 +2,13 @@ package sw.momolab.server.service.userService;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import sw.momolab.server.apiPayload.code.status.ErrorStatus;
 import sw.momolab.server.apiPayload.exception.UserHandler;
 import sw.momolab.server.converter.UserConverter;
 import sw.momolab.server.domain.User;
 import sw.momolab.server.repository.RecordRepository;
 import sw.momolab.server.repository.UserRepository;
-import sw.momolab.server.web.dto.AuthDTO.AuthRequestDTO;
 import sw.momolab.server.web.dto.UserDTO.UserResponseDTO;
 
 import java.time.LocalDate;
@@ -22,18 +22,7 @@ public class UserQueryServiceImpl implements UserQueryService {
     private final UserRepository userRepository;
 
     @Override
-    public String getRecordDate(Long userId) {
-        // 사용자가 처음으로 일기를 작성한 날짜 조회
-        LocalDate firstRecordDate = recordRepository.findFirstRecordDateByUserId(userId)
-                .orElse(LocalDate.now()); // 작성 기록이 없으면 오늘 날짜를 기본값으로 사용
-
-        // 오늘 날짜와의 차이를 계산
-        long days = ChronoUnit.DAYS.between(firstRecordDate, LocalDate.now());
-
-        return "D+" + days;
-    }
-
-    @Override
+    @Transactional(readOnly = true)
     public UserResponseDTO.MyPageDTO getMyPage(Long userId) {
 
         User user = userRepository.findById(userId)
@@ -43,7 +32,8 @@ public class UserQueryServiceImpl implements UserQueryService {
         LocalDate firstRecordDate = recordRepository.findFirstRecordDateByUserId(userId)
                 .orElse(LocalDate.now()); // 작성 기록이 없으면 오늘 날짜를 기본값으로 사용
 
-        String dPlusPeriod = getRecordDate(userId); // 기록을 작성해온 기간
+        long days = ChronoUnit.DAYS.between(firstRecordDate, LocalDate.now());
+        String dPlusPeriod = "D+" + days;
 
         return UserConverter.toMyPageDTO(user, firstRecordDate, dPlusPeriod);
     }

--- a/src/main/java/sw/momolab/server/service/userService/UserQueryServiceImpl.java
+++ b/src/main/java/sw/momolab/server/service/userService/UserQueryServiceImpl.java
@@ -1,0 +1,50 @@
+package sw.momolab.server.service.userService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sw.momolab.server.apiPayload.code.status.ErrorStatus;
+import sw.momolab.server.apiPayload.exception.UserHandler;
+import sw.momolab.server.converter.UserConverter;
+import sw.momolab.server.domain.User;
+import sw.momolab.server.repository.RecordRepository;
+import sw.momolab.server.repository.UserRepository;
+import sw.momolab.server.web.dto.AuthDTO.AuthRequestDTO;
+import sw.momolab.server.web.dto.UserDTO.UserResponseDTO;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+@Service
+@RequiredArgsConstructor
+public class UserQueryServiceImpl implements UserQueryService {
+
+    private final RecordRepository recordRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public String getRecordDate(Long userId) {
+        // 사용자가 처음으로 일기를 작성한 날짜 조회
+        LocalDate firstRecordDate = recordRepository.findFirstRecordDateByUserId(userId)
+                .orElse(LocalDate.now()); // 작성 기록이 없으면 오늘 날짜를 기본값으로 사용
+
+        // 오늘 날짜와의 차이를 계산
+        long days = ChronoUnit.DAYS.between(firstRecordDate, LocalDate.now());
+
+        return "D+" + days;
+    }
+
+    @Override
+    public UserResponseDTO.MyPageDTO getMyPage(Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 사용자가 처음으로 일기를 작성한 날짜 조회
+        LocalDate firstRecordDate = recordRepository.findFirstRecordDateByUserId(userId)
+                .orElse(LocalDate.now()); // 작성 기록이 없으면 오늘 날짜를 기본값으로 사용
+
+        String dPlusPeriod = getRecordDate(userId); // 기록을 작성해온 기간
+
+        return UserConverter.toMyPageDTO(user, firstRecordDate, dPlusPeriod);
+    }
+}

--- a/src/main/java/sw/momolab/server/service/userService/UserQueryServiceImpl.java
+++ b/src/main/java/sw/momolab/server/service/userService/UserQueryServiceImpl.java
@@ -13,27 +13,36 @@ import sw.momolab.server.web.dto.UserDTO.UserResponseDTO;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserQueryServiceImpl implements UserQueryService {
 
     private final RecordRepository recordRepository;
     private final UserRepository userRepository;
 
     @Override
-    @Transactional(readOnly = true)
     public UserResponseDTO.MyPageDTO getMyPage(Long userId) {
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         // 사용자가 처음으로 일기를 작성한 날짜 조회
-        LocalDate firstRecordDate = recordRepository.findFirstRecordDateByUserId(userId)
-                .orElse(LocalDate.now()); // 작성 기록이 없으면 오늘 날짜를 기본값으로 사용
+        Optional<LocalDate> firstRecordDateOpt = recordRepository.findFirstRecordDateByUserId(userId);
 
-        long days = ChronoUnit.DAYS.between(firstRecordDate, LocalDate.now());
-        String dPlusPeriod = "D+" + days;
+        LocalDate firstRecordDate;
+        String dPlusPeriod;
+
+        if (firstRecordDateOpt.isPresent()) {
+            firstRecordDate = firstRecordDateOpt.get();
+            long days = ChronoUnit.DAYS.between(firstRecordDate, LocalDate.now());
+            dPlusPeriod = "D+" + days;
+        } else {
+            firstRecordDate = null;
+            dPlusPeriod = "기록 없음";
+        }
 
         return UserConverter.toMyPageDTO(user, firstRecordDate, dPlusPeriod);
     }

--- a/src/main/java/sw/momolab/server/web/controller/UserController.java
+++ b/src/main/java/sw/momolab/server/web/controller/UserController.java
@@ -1,0 +1,31 @@
+package sw.momolab.server.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sw.momolab.server.apiPayload.ApiResponse;
+import sw.momolab.server.service.userService.UserQueryService;
+import sw.momolab.server.web.dto.AuthDTO.AuthRequestDTO;
+import sw.momolab.server.web.dto.UserDTO.UserResponseDTO;
+
+@Tag(name = "users", description = "사용자 관련 API")
+@RestController
+@Validated
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+    private final UserQueryService userQueryService;
+
+    @GetMapping("/mypage")
+    @Operation(summary = "마이페이지 조회 API", description = "사용자의 아이디와 최초 기록 날짜, 기록을 작성해온 기간을 조회합니다.")
+    public ApiResponse<UserResponseDTO.MyPageDTO> getMyPage(@AuthenticationPrincipal(expression = "id") Long userId) {
+        UserResponseDTO.MyPageDTO result = userQueryService.getMyPage(userId);
+        return ApiResponse.onSuccess(result);
+    }
+}

--- a/src/main/java/sw/momolab/server/web/dto/UserDTO/UserResponseDTO.java
+++ b/src/main/java/sw/momolab/server/web/dto/UserDTO/UserResponseDTO.java
@@ -1,0 +1,27 @@
+package sw.momolab.server.web.dto.UserDTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+public class UserResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(title = "마이페이지 응답 dto")
+    public static class MyPageDTO {
+        @Schema(description = "환자 ID", example = "P12345678")
+        private String loginId;
+
+        @Schema(description = "투석 시작일")
+        private LocalDate recordStartDate;
+
+        @Schema(description = "기록 일지를 작성해온 기간", example = "D+15")
+        private String recordPeriod;
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
환자의 ID와 투석 시작일(최초 작성일), 기록을 작성해온 기간을 조회합니다.

## 🔍 테스트 방법
<!-- 테스트 방법을 간략히 설명해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 마이페이지 조회 기능 추가: 인증된 사용자는 자신의 ID, 투석 기록 시작일, 기록 기간(D+형식)을 확인할 수 있습니다.
  * 신규 API GET /api/v1/users/mypage 추가 및 응답 DTO 제공.
  * 기록 기간 자동 계산: 최초 기록일 기준 D+N 표기, 기록이 없을 경우 "기록 없음"으로 표시.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->