### PR TITLE
[Feat/#36] 로그인한 상태에서 비밀번호 재설정 로직 구현

### DIFF
--- a/src/main/java/sw/momolab/server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/sw/momolab/server/apiPayload/code/status/ErrorStatus.java
@@ -27,6 +27,8 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_STATUS_INACTIVE(HttpStatus.FORBIDDEN, "USER_403_01", "탈퇴한 사용자입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_404_01", "사용자를 찾을 수 없습니다."),
 
+    PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "PWD_400_01", "비밀번호 확인이 일치하지 않습니다."),
+    PASSWORD_UPDATE_NO_CHANGE(HttpStatus.BAD_REQUEST, "PWD_400_02", "새로운 비밀번호를 입력해주세요."),
 
     ;
 

--- a/src/main/java/sw/momolab/server/domain/User.java
+++ b/src/main/java/sw/momolab/server/domain/User.java
@@ -63,6 +63,10 @@ public class User extends BaseEntity {
         this.refreshToken = refreshTokenEntity;
     }
 
+    public void encodePassword(String password) {
+        this.password = password;
+    }
+
     public void deleteRefreshToken() {
         this.refreshToken = null;
     }

--- a/src/main/java/sw/momolab/server/service/userService/UserCommandService.java
+++ b/src/main/java/sw/momolab/server/service/userService/UserCommandService.java
@@ -1,0 +1,7 @@
+package sw.momolab.server.service.userService;
+
+import sw.momolab.server.web.dto.UserDTO.UserRequestDTO;
+
+public interface UserCommandService {
+    void resetPassword(Long userId, UserRequestDTO.ResetPasswordDTO request);
+}

--- a/src/main/java/sw/momolab/server/service/userService/UserCommandService.java
+++ b/src/main/java/sw/momolab/server/service/userService/UserCommandService.java
@@ -3,5 +3,5 @@ package sw.momolab.server.service.userService;
 import sw.momolab.server.web.dto.UserDTO.UserRequestDTO;
 
 public interface UserCommandService {
-    void resetPassword(Long userId, UserRequestDTO.ResetPasswordDTO request);
+    void updatePassword(Long userId, UserRequestDTO.ResetPasswordDTO request);
 }

--- a/src/main/java/sw/momolab/server/service/userService/UserCommandServiceImpl.java
+++ b/src/main/java/sw/momolab/server/service/userService/UserCommandServiceImpl.java
@@ -1,0 +1,39 @@
+package sw.momolab.server.service.userService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sw.momolab.server.apiPayload.code.status.ErrorStatus;
+import sw.momolab.server.apiPayload.exception.UserHandler;
+import sw.momolab.server.domain.User;
+import sw.momolab.server.domain.enums.UserStatus;
+import sw.momolab.server.repository.UserRepository;
+import sw.momolab.server.web.dto.UserDTO.UserRequestDTO;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserCommandServiceImpl implements UserCommandService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void resetPassword(Long userId, UserRequestDTO.ResetPasswordDTO request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        if (user.getStatus() == UserStatus.INACTIVE)
+            throw new UserHandler(ErrorStatus.USER_STATUS_INACTIVE);
+
+        // 비밀번호 변경사항 없을 때 예외 처리
+        String rawPassword = request.getPassword();
+        if (passwordEncoder.matches(rawPassword, user.getPassword())) {
+            throw new UserHandler(ErrorStatus.PASSWORD_UPDATE_NO_CHANGE);
+        }
+
+        String hashedPassword = passwordEncoder.encode(request.getPassword());
+        user.encodePassword(hashedPassword); //사용자 비밀번호 변경
+    }
+}

--- a/src/main/java/sw/momolab/server/service/userService/UserCommandServiceImpl.java
+++ b/src/main/java/sw/momolab/server/service/userService/UserCommandServiceImpl.java
@@ -20,12 +20,17 @@ public class UserCommandServiceImpl implements UserCommandService {
     private final PasswordEncoder passwordEncoder;
 
     @Override
-    public void resetPassword(Long userId, UserRequestDTO.ResetPasswordDTO request) {
+    public void updatePassword(Long userId, UserRequestDTO.ResetPasswordDTO request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         if (user.getStatus() == UserStatus.INACTIVE)
             throw new UserHandler(ErrorStatus.USER_STATUS_INACTIVE);
+
+        // 비밀번호 확인 불일치 예외 처리
+        if (!request.getPassword().equals(request.getPasswordCheck())) {
+            throw new UserHandler(ErrorStatus.PASSWORD_NOT_MATCH);
+        }
 
         // 비밀번호 변경사항 없을 때 예외 처리
         String rawPassword = request.getPassword();

--- a/src/main/java/sw/momolab/server/web/controller/UserController.java
+++ b/src/main/java/sw/momolab/server/web/controller/UserController.java
@@ -2,6 +2,7 @@ package sw.momolab.server.web.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -31,8 +32,8 @@ public class UserController {
 
     @PatchMapping("/password")
     @Operation(summary = "비밀번호 재설정 API", description = "로그인한 사용자의 비밀번호를 재설정합니다.")
-    public ApiResponse<Void> resetPassword(@AuthenticationPrincipal(expression = "id") Long userId, @RequestBody UserRequestDTO.ResetPasswordDTO request) {
-        userCommandService.resetPassword(userId, request);
+    public ApiResponse<Void> updatePassword(@AuthenticationPrincipal(expression = "id") Long userId, @RequestBody @Valid UserRequestDTO.ResetPasswordDTO request) {
+        userCommandService.updatePassword(userId, request);
         return ApiResponse.onSuccess();
     }
 }

--- a/src/main/java/sw/momolab/server/web/controller/UserController.java
+++ b/src/main/java/sw/momolab/server/web/controller/UserController.java
@@ -5,12 +5,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import sw.momolab.server.apiPayload.ApiResponse;
+import sw.momolab.server.service.userService.UserCommandService;
 import sw.momolab.server.service.userService.UserQueryService;
-import sw.momolab.server.web.dto.AuthDTO.AuthRequestDTO;
+import sw.momolab.server.web.dto.UserDTO.UserRequestDTO;
 import sw.momolab.server.web.dto.UserDTO.UserResponseDTO;
 
 @Tag(name = "users", description = "사용자 관련 API")
@@ -21,11 +20,19 @@ import sw.momolab.server.web.dto.UserDTO.UserResponseDTO;
 public class UserController {
 
     private final UserQueryService userQueryService;
+    private final UserCommandService userCommandService;
 
     @GetMapping("/mypage")
     @Operation(summary = "마이페이지 조회 API", description = "사용자의 아이디와 최초 기록 날짜, 기록을 작성해온 기간을 조회합니다.")
     public ApiResponse<UserResponseDTO.MyPageDTO> getMyPage(@AuthenticationPrincipal(expression = "id") Long userId) {
         UserResponseDTO.MyPageDTO result = userQueryService.getMyPage(userId);
         return ApiResponse.onSuccess(result);
+    }
+
+    @PatchMapping("/password")
+    @Operation(summary = "비밀번호 재설정 API", description = "로그인한 사용자의 비밀번호를 재설정합니다.")
+    public ApiResponse<Void> resetPassword(@AuthenticationPrincipal(expression = "id") Long userId, @RequestBody UserRequestDTO.ResetPasswordDTO request) {
+        userCommandService.resetPassword(userId, request);
+        return ApiResponse.onSuccess();
     }
 }

--- a/src/main/java/sw/momolab/server/web/controller/UserController.java
+++ b/src/main/java/sw/momolab/server/web/controller/UserController.java
@@ -23,7 +23,7 @@ public class UserController {
     private final UserCommandService userCommandService;
 
     @GetMapping("/mypage")
-    @Operation(summary = "마이페이지 조회 API", description = "사용자의 아이디와 최초 기록 날짜, 기록을 작성해온 기간을 조회합니다.")
+    @Operation(summary = "마이페이지 조회 API", description = "사용자의 아이디와 최초 기록 날짜, 기록을 작성해온 기간, 그리고 마지막으로 로그인한 날짜와 시각을 조회합니다.")
     public ApiResponse<UserResponseDTO.MyPageDTO> getMyPage(@AuthenticationPrincipal(expression = "id") Long userId) {
         UserResponseDTO.MyPageDTO result = userQueryService.getMyPage(userId);
         return ApiResponse.onSuccess(result);

--- a/src/main/java/sw/momolab/server/web/dto/UserDTO/UserRequestDTO.java
+++ b/src/main/java/sw/momolab/server/web/dto/UserDTO/UserRequestDTO.java
@@ -1,0 +1,28 @@
+package sw.momolab.server.web.dto.UserDTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserRequestDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(title = "비밀번호 재설정 요청 dto")
+    public static class ResetPasswordDTO {
+
+        @Schema(description = "변경하려는 비밀번호 입력", example = "aidi2025")
+        @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+        @Pattern(regexp = "^(?=.*\\d).{8,30}$", message = "비밀번호는 8~30자 이내이며, 최소 1개의 숫자를 포함해야 합니다.")
+        private String password;
+
+        @Schema(description = "변경하려는 비밀번호 재입력", example = "aidi2025")
+        @NotBlank(message = "비밀번호 확인은 필수 입력 항목입니다.")
+        private String passwordCheck;
+    }
+}

--- a/src/main/java/sw/momolab/server/web/dto/UserDTO/UserResponseDTO.java
+++ b/src/main/java/sw/momolab/server/web/dto/UserDTO/UserResponseDTO.java
@@ -25,7 +25,7 @@ public class UserResponseDTO {
         @Schema(description = "기록 일지를 작성해온 기간", example = "D+15")
         private String recordPeriod;
 
-        @Schema(description = "마지막으로 로그인한 날짜")
+        @Schema(description = "마지막으로 로그인한 날짜와 시각")
         private LocalDateTime lastLoginAt;
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
로그인한 상태에서 비밀번호 재설정 로직 구현하였습니다.
로그인하지 않은 상태에서의 비밀번호 재설정 api는 사용자 인증 방식이 필요한데, 환자의 고유번호와 비밀번호 컬럼만 존재하는 상황이기 때문에 EMR 연동 이후에 인증 방식을 추가하거나 병원측에 연락을 하여 비밀번호를 재설정하는 방식으로 진행될 것 같습니다.

## 🔍 테스트 방법
<!-- 테스트 방법을 간략히 설명해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 비밀번호 재설정 기능 추가: 인증된 사용자가 새 비밀번호를 설정할 수 있습니다. 비밀번호는 8-30자이며 숫자 포함 규칙이 적용됩니다.
  * 동일한 비밀번호로의 변경은 거부됩니다.

* **Bug Fixes / Validation**
  * 비밀번호와 확인 입력 불일치 시 명확한 오류 안내를 추가했습니다.
  * 새 비밀번호 미입력(변경 없음) 시 별도 오류 메시지를 제공합니다.

* **Documentation**
  * 마이페이지의 마지막 로그인 설명을 "날짜와 시각"으로 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->